### PR TITLE
Use var for ES5 example

### DIFF
--- a/es5.js
+++ b/es5.js
@@ -1,7 +1,7 @@
 (function() {
   console.log('Some good ole ES5 JavaScript');
 
-  const es5El = document.createElement('div');
+  var es5El = document.createElement('div');
   es5El.innerHTML = 'ES5 JS';
   document.getElementById('root-es5').appendChild(es5El);
 })();


### PR DESCRIPTION
`const` is ES6, but it also happens to be supported in IE11 so the `es5.js` script still works.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const#Specifications